### PR TITLE
Updated __main__.py and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-#### nh-pdf-downloader
-*_IMPORTATN UPDATE (6/18): nhentai has recently updated their website that changes the webpage structure of a given doujin. This project has been updated for the new changes. If your previous download of this repo did not work, please redownload / reclown now. Thank you_*
 # nhentai PDF Downloader
 > Downloads and coverts any doujin/manga from nhentai to PDF
 
@@ -12,12 +10,6 @@
 $ pip3 install --upgrade pip
 $ pip3 install -r requirements.txt
 ```
-#### Build
-> Use Pyinstaller and Anaconda to build
-```
-$ pip install pyinstaller
-$ pyinstaller __main__.py
-```
 
 ## Running the Script
 > Navigate to the repo directory on your local machine. Then execute the following:
@@ -25,7 +17,14 @@ $ pyinstaller __main__.py
 $ python3 __main__.py
 ```
 
-## Running the build
+## Build
+> Use Pyinstaller and Anaconda to build
+```
+$ pip install pyinstaller
+$ pyinstaller __main__.py
+```
+
+#### Running the build
 _Windows_
 > Navigate to the dist directory ```cd dist\__main__\```
 ```
@@ -38,16 +37,52 @@ $ __main__.out
 ```
 
 ## Usage
-* Use a (or multiple) doujin ID number(s) (which can be found in the URL; for instance, ```152969```).
-* Enter those number when prompted (if multiple, separate by space).
-* The program will download and covert all images into a pdf and save it in a subfolder where the python script is.
 ```
-- nh-pdf-downloader/
-    - hentai/
-        - example1.pdf
-        - example2.pdf
-    - __main__.py
+[ To Download ]
+    - Enter in the ID number(s)/webpage URL(s) of the doujin you wish to download.
+    Note: Doujins must come from nhentai website. 
+          This script will not work with any other site.
+    Hint: ID numbers can be found in the URL. 
+          https://nhentai.net/g/[id number]/
+    - To create a queue (multiple downloads) enter all the ID numbers
+    Note: -The order of the ID's does not matter.
+          -ID(s) need any non numeric delimiter whether it be whitespace or hypen or mixed, whereas URL(s) 
+           do not need any as each consecutive group of numbers is considered as one Id
+    - Hit enter to begin downloading
+    Note: If a doujin has the same name as an already downloaded item,
+          then it will skip that download.
+          If a doujin has a name that is too long, a warning will
+          appear and prompt to enter a new name.
+    Example:
+    Enter ID(s)/webpage URL(s)/Command: 111111 222222,333333https://nhentai.net/g/444444https://nhentai.net/g/555555
+
+[ Batch Downloading from text file ]
+    -You can copy paste all the links of the doujins you want to download into a text file and set
+     the value of batch in the config.txt to the path of this text file.
+    Example: 
+        Assume the text file "test.txt" in the same folder as the script has the following contents:
+            111111 222222https://nhentai.net/g/444444https://nhentai.net/g/555555
+            nhentai.net/g/666666
+        Then all you have to do is set the value of the batch line to 
+            batch = ".\\test.txt"
+        and all the doujins posted will be downloaded when the script is run
+    Note: The batch line in the config.txt will be reset every time the script is executed
+
+[ Other Options ]
+    When prompted, you may enter one of the other commands:
+    - done : this will end execution of the program
+    - help : this will display this text
+    - open : this will open finder/files/file explorer to the
+             default download folder
+
+[ Threads ]
+    - Set this option in the config file to specify how many pages of the same doujin are to be downloaded at once
+
+[ Type ]
+    - Set this option in the config file to specify the file type that the doujins to be saved as(pdf, cbt, cbz).
 ```
+> _Note: A config file will be created automatically if it does not exist in the same folder as the script._
+ 
 > _Note: as the images are being downloaded, a temporary folder is created to store the images. this folder will be deleted upon completion._
 * When you are done, enter ```done``` to exit script
 
@@ -55,8 +90,8 @@ $ __main__.out
 Feel free to request features. 
 #### Planned Features
 - [x] ~Enter multiple numbers at once (and let the script download all)~
-- [ ] Create a config file that would allow the user to specify an output folder (and call it whatever they want)
-- [ ] Add CBR/CBZ support
+- [x] Create a config file that would allow the user to specify an output folder (and call it whatever they want)
+- [x] Add CBR/CBZ support
 - [ ] Add config for automatically putting downloaded PDF into a subfolder named after its parody, author, or language.
 #### Considering
 > Features that will be added if enough people request them


### PR DESCRIPTION
### \_\_main\_\_.py changes:
  1) Added threads(see point 3)
  2) Added support for cbr,cbz,cbt(see point 3)
  3) Added additional info and 2 new parameters to the config file:
      a) threads: Used to set how many threads are to be used for downloading, i.e how many pages are to be downloaded at once
      b) type: Set the file extension that the doujin is to be saved as. Currently supports pdf(default), cbr, cbt, cbz. Note that the compression used for all 3 CBx formats is zip(it just works)
  4) Modified the import statements a bit.
  5) Changed the downloading progress section in the script to a nice tabular form
  6) Some minor string and formatting changes

### README.MD changes:
- Updated the readme file

### Note:
- For automatically putting downloaded PDF into a subfolder named after its parody, author, or language, the tags etc need to be extracted similar to how you extracted the title name, page count etc. But I don't know how to do that hence I left it